### PR TITLE
#51: Find issues in nonstandard source file layouts

### DIFF
--- a/src/main/java/org/sonar/plugins/findbugs/resource/ByteCodeResourceLocator.java
+++ b/src/main/java/org/sonar/plugins/findbugs/resource/ByteCodeResourceLocator.java
@@ -124,6 +124,11 @@ public class ByteCodeResourceLocator implements BatchExtension {
     }
 
     public InputFile buildInputFile(String fileName,FileSystem fs) {
+        for (InputFile f : fs.inputFiles(fs.predicates().hasType(InputFile.Type.MAIN))) {
+            if (f.relativePath().endsWith(fileName)) {
+                return f;
+            }
+        }
         for(String sourceDir : SOURCE_DIRECTORIES) {
             //System.out.println("Source file tested : "+sourceDir+"/"+fileName);
             Iterable<InputFile> files = fs.inputFiles(fs.predicates().hasRelativePath(sourceDir+"/"+fileName));

--- a/src/test/java/org/sonar/plugins/findbugs/FindbugsSensorTest.java
+++ b/src/test/java/org/sonar/plugins/findbugs/FindbugsSensorTest.java
@@ -72,6 +72,7 @@ public class FindbugsSensorTest extends FindbugsTests {
     javaResourceLocator = mockJavaResourceLocator();
 
     InputFile dummyFile = mock(InputFile.class);
+    when(dummyFile.relativePath()).thenReturn("src/main/java/com/helloworld/DummyFile.java");
     //Will make sure that the lookup on the filesystem will always find a file.
     when(fs.inputFiles(any(FilePredicate.class))).thenReturn(Arrays.asList(dummyFile));
 

--- a/src/test/java/org/sonar/plugins/findbugs/resource/ByteCodeResourceLocatorTest.java
+++ b/src/test/java/org/sonar/plugins/findbugs/resource/ByteCodeResourceLocatorTest.java
@@ -7,9 +7,12 @@ import org.sonar.api.batch.fs.FilePredicate;
 import org.sonar.api.batch.fs.FilePredicates;
 import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.batch.fs.internal.DefaultInputFile;
+import org.sonar.api.internal.google.common.collect.ImmutableList;
 
 import java.util.ArrayList;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -89,5 +92,12 @@ public class ByteCodeResourceLocatorTest {
 
   }
 
+  @Test
+  public void findRegularSourceFile() throws Exception {
+    DefaultInputFile givenJavaFile = new DefaultInputFile("TestJavaClass", "app/src/main/java/com/helloworld/TestJavaClass.java");
+    when(fsEmpty.inputFiles(any(FilePredicate.class))).thenReturn(ImmutableList.<InputFile>of(givenJavaFile));
 
+    ByteCodeResourceLocator locator = new ByteCodeResourceLocator();
+    assertEquals(givenJavaFile, locator.findJavaClassFile("com.helloworld.TestJavaClass$1", fsEmpty));
+  }
 }


### PR DESCRIPTION
See issue #51 ...

I tried to generally preserve original behaviour. But if given class is a suffix for some known InputFile then take that one.