### PR TITLE
Register experimental rules

### DIFF
--- a/generate_profiles/BuildXmlFiles.groovy
+++ b/generate_profiles/BuildXmlFiles.groovy
@@ -1,7 +1,7 @@
 import groovy.xml.MarkupBuilder
 
 @Grapes([
-    @Grab(group='com.google.code.findbugs'  , module='findbugs', version='3.0.1'),
+    @Grab(group='com.github.spotbugs', module='spotbugs', version='3.1.0-RC1'),
     @Grab(group='com.mebigfatguy.fb-contrib', module='fb-contrib', version='7.0.0'),
     @Grab(group='com.h3xstream.findsecbugs' , module='findsecbugs-plugin', version='1.6.0')]
 )
@@ -189,7 +189,7 @@ String getFindBugsCategory(List<Plugin> plugins, String bugType) {
     return "EXPERIMENTAL"
 }
 
-FB = new Plugin(groupId: 'com.google.code.findbugs', artifactId: 'findbugs', version: '3.0.1')
+FB = new Plugin(groupId: 'com.github.spotbugs', artifactId: 'spotbugs', version: '3.1.0-RC1')
 CONTRIB = new Plugin(groupId: 'com.mebigfatguy.fb-contrib', artifactId: 'fb-contrib', version: '7.0.0')
 FSB = new Plugin(groupId: 'com.h3xstream.findsecbugs', artifactId: 'findsecbugs-plugin', version: '1.6.0')
 
@@ -216,7 +216,7 @@ def writeRules(String rulesSetName,List<Plugin> plugins,List<String> includedBug
 
             category = getFindBugsCategory(plugins, pattern.attribute("type"))
 
-            if(category == "EXPERIMENTAL" || category == "NOISE") return;
+            if(category == "NOISE" || pattern.attribute("type") in ["TESTING", "TESTING1", "TESTING2", "TESTING3", "UNKNOWN"]) return;
             if(category == "MT_CORRECTNESS") category = "MULTI-THREADING"
 
             //if(rulesSetName == 'jsp') println pattern.attribute("type")

--- a/src/main/java/org/sonar/plugins/findbugs/rules/FbContribRulesDefinition.java
+++ b/src/main/java/org/sonar/plugins/findbugs/rules/FbContribRulesDefinition.java
@@ -28,6 +28,7 @@ public class FbContribRulesDefinition implements RulesDefinition {
   public static final String REPOSITORY_KEY = "fb-contrib";
   public static final String REPOSITORY_NAME = "FindBugs Contrib";
   public static final int RULE_COUNT = 275;
+  public static final int DEACTIVED_RULE_COUNT = 2;
 
   @Override
   public void define(Context context) {

--- a/src/main/java/org/sonar/plugins/findbugs/rules/FindbugsRulesDefinition.java
+++ b/src/main/java/org/sonar/plugins/findbugs/rules/FindbugsRulesDefinition.java
@@ -30,6 +30,7 @@ public final class FindbugsRulesDefinition implements RulesDefinition {
   public static final String REPOSITORY_KEY = "findbugs";
   public static final String REPOSITORY_NAME = "FindBugs";
   public static final int RULE_COUNT = 452;
+  public static final int DEACTIVED_RULE_COUNT = 6;
 
   @Override
   public void define(Context context) {

--- a/src/main/resources/org/sonar/plugins/findbugs/rules-fbcontrib.xml
+++ b/src/main/resources/org/sonar/plugins/findbugs/rules-fbcontrib.xml
@@ -1852,6 +1852,22 @@ return new String[0];&lt;br/&gt;
     <tag>performance</tag>
     <tag>bug</tag>
   </rule>
+  <rule key='LO_EMBEDDED_SIMPLE_STRING_FORMAT_IN_FORMAT_STRING' priority='INFO'>
+    <name>Experimental - Method passes a simple String.format result to an SLF4J's format string</name>
+    <configKey>LO_EMBEDDED_SIMPLE_STRING_FORMAT_IN_FORMAT_STRING</configKey>
+    <description>&lt;p&gt;This method uses an SLF4J logger to log a string, which was produced through a call to String.format, where
+	       the format string passed was a constant string containing only simple format markers that could be directly handled
+	       by slf4j. Rather than doing
+	       &lt;pre&gt;
+	          logger.error("String.format("This %s is an error", s));
+	       &lt;pre&gt;
+	       do
+	       &lt;pre&gt;
+	          logger.error(This {} is an error", s);
+	       &lt;/pre&gt;
+	       &lt;/p&gt;</description>
+    <tag>experimental</tag>
+  </rule>
   <rule key='IICU_INCORRECT_INTERNAL_CLASS_USE' priority='MAJOR'>
     <name>Correctness - Class relies on internal API classes</name>
     <configKey>IICU_INCORRECT_INTERNAL_CLASS_USE</configKey>
@@ -3051,6 +3067,21 @@ if (shouldCalcHalting &amp;&amp; (calculateHaltingProbability() &amp;gt; 0) { }
     		converting byte data to characters, when there is no need to do this. Use stream based inputs for better performance.&lt;/p&gt;</description>
     <tag>performance</tag>
     <tag>bug</tag>
+  </rule>
+  <rule key='IOI_USE_OF_FILE_STREAM_CONSTRUCTORS' priority='INFO'>
+    <name>Experimental - Method uses a FileInputStream or FileOutputStream constructor</name>
+    <configKey>IOI_USE_OF_FILE_STREAM_CONSTRUCTORS</configKey>
+    <description>&lt;p&gt;This method creates and uses a java.io.FileInputStream or java.io.FileOutputStream object. Unfortunately both
+    		of these classes implement a finalize method, which means that objects created will likely hang around until a 
+    		full garbage collection occurs, which will leave excessive garbage on the heap for longer, and potentially much
+    		longer than expected. Java 7 introduced two ways to create streams for reading and writing files that do not have this concern.
+    		You should consider switching from these above classes to
+    		&lt;code&gt;
+    		InputStream is = java.nio.file.Files.newInputStream(myfile.toPath());
+    		OutputStream os = java.nio.file.Files.newOutputStream(myfile.toPath());
+    		&lt;/code&gt;
+    		&lt;/p&gt;</description>
+    <tag>experimental</tag>
   </rule>
   <rule key='DMC_DUBIOUS_MAP_COLLECTION' priority='MAJOR'>
     <name>Correctness - Class holds a map-type field, but uses it as only a List</name>

--- a/src/main/resources/org/sonar/plugins/findbugs/rules-findbugs.xml
+++ b/src/main/resources/org/sonar/plugins/findbugs/rules-findbugs.xml
@@ -5,6 +5,13 @@
     <description>&lt;p&gt;It's recommended to use the predefined library constant for code clarity and better precision.&lt;/p&gt;</description>
     <tag>bad-practice</tag>
   </rule>
+  <rule key='SKIPPED_CLASS_TOO_BIG' priority='INFO'>
+    <name>Experimental - Class too big for analysis</name>
+    <configKey>SKIPPED_CLASS_TOO_BIG</configKey>
+    <description>&lt;p&gt;This class is bigger than can be effectively handled, and was not fully analyzed for errors.
+&lt;/p&gt;</description>
+    <tag>experimental</tag>
+  </rule>
   <rule key='DMI_BIGDECIMAL_CONSTRUCTED_FROM_DOUBLE' priority='MAJOR'>
     <name>Correctness - BigDecimal constructed from double that isn't represented precisely</name>
     <configKey>DMI_BIGDECIMAL_CONSTRUCTED_FROM_DOUBLE</configKey>
@@ -38,7 +45,7 @@ This partical method invocation doesn't make sense, for reasons that should be a
   <rule key='DMI_SCHEDULED_THREAD_POOL_EXECUTOR_WITH_ZERO_CORE_THREADS' priority='MAJOR'>
     <name>Correctness - Creation of ScheduledThreadPoolExecutor with zero core threads</name>
     <configKey>DMI_SCHEDULED_THREAD_POOL_EXECUTOR_WITH_ZERO_CORE_THREADS</configKey>
-    <description>&lt;p&gt;(&lt;a href="http://java.sun.com/javase/6/docs/api/java/util/concurrent/ScheduledThreadPoolExecutor.html#ScheduledThreadPoolExecutor(int)"&gt;Javadoc&lt;/a&gt;)
+    <description>&lt;p&gt;(&lt;a href="http://docs.oracle.com/javase/6/docs/api/java/util/concurrent/ScheduledThreadPoolExecutor.html#ScheduledThreadPoolExecutor%28int%29"&gt;Javadoc&lt;/a&gt;)
 A ScheduledThreadPoolExecutor with zero core threads will never execute anything; changes to the max pool size are ignored.
 &lt;/p&gt;</description>
     <tag>correctness</tag>
@@ -47,7 +54,7 @@ A ScheduledThreadPoolExecutor with zero core threads will never execute anything
   <rule key='DMI_FUTILE_ATTEMPT_TO_CHANGE_MAXPOOL_SIZE_OF_SCHEDULED_THREAD_POOL_EXECUTOR' priority='MAJOR'>
     <name>Correctness - Futile attempt to change max pool size of ScheduledThreadPoolExecutor</name>
     <configKey>DMI_FUTILE_ATTEMPT_TO_CHANGE_MAXPOOL_SIZE_OF_SCHEDULED_THREAD_POOL_EXECUTOR</configKey>
-    <description>&lt;p&gt;(&lt;a href="http://java.sun.com/javase/6/docs/api/java/util/concurrent/ScheduledThreadPoolExecutor.html"&gt;Javadoc&lt;/a&gt;)
+    <description>&lt;p&gt;(&lt;a href="http://docs.oracle.com/javase/6/docs/api/java/util/concurrent/ScheduledThreadPoolExecutor.html"&gt;Javadoc&lt;/a&gt;)
 While ScheduledThreadPoolExecutor inherits from ThreadPoolExecutor, a few of the inherited tuning methods are not useful for it. In particular, because it acts as a fixed-sized pool using corePoolSize threads and an unbounded queue, adjustments to maximumPoolSize have no useful effect.
     &lt;/p&gt;</description>
     <tag>correctness</tag>
@@ -245,9 +252,9 @@ another package.&lt;/p&gt;</description>
     <name>Correctness - Method with Optional return type returns explicit null</name>
     <configKey>NP_OPTIONAL_RETURN_NULL</configKey>
     <description>&lt;p&gt;
-    The usage of Optional return type (java.util.Optional or com.google.common.base.Optiona) 
-    always mean that explicit null returns were not desired by design.
-    Returning a null value in such case is a contract violation and will most likely break clients code.
+    The usage of Optional return type (java.util.Optional or com.google.common.base.Optional)
+    always means that explicit null returns were not desired by design.
+    Returning a null value in such case is a contract violation and will most likely break client code.
        &lt;/p&gt;</description>
     <tag>correctness</tag>
     <tag>bug</tag>
@@ -434,6 +441,14 @@ will need to be changed in order to compile it in later versions of Java.&lt;/p&
   If this code will be granted security permissions, but might be invoked by code that does not
   have security permissions, then the invocation needs to occur inside a doPrivileged block.&lt;/p&gt;</description>
     <tag>malicious-code</tag>
+  </rule>
+  <rule key='DP_DO_INSIDE_DO_PRIVILEDGED' priority='INFO'>
+    <name>Experimental - Method invoked that should be only be invoked inside a doPrivileged block</name>
+    <configKey>DP_DO_INSIDE_DO_PRIVILEDGED</configKey>
+    <description>&lt;p&gt; This code invokes a method that requires a security permission check.
+  If this code will be granted security permissions, but might be invoked by code that does not
+  have security permissions, then the invocation needs to occur inside a doPrivileged block.&lt;/p&gt;</description>
+    <tag>experimental</tag>
   </rule>
   <rule key='DP_CREATE_CLASSLOADER_INSIDE_DO_PRIVILEGED' priority='INFO'>
     <name>Malicious code - Classloaders should only be created inside doPrivileged block</name>
@@ -708,7 +723,7 @@ to immediately undo the work of the boxing.
     <name>Correctness - Random value from 0 to 1 is coerced to the integer 0</name>
     <configKey>RV_01_TO_INT</configKey>
     <description>&lt;p&gt;A random value from 0 to 1 is being coerced to the integer value 0. You probably
-want to multiple the random value by something else before coercing it to an integer, or use the &lt;code&gt;Random.nextInt(n)&lt;/code&gt; method.
+want to multiply the random value by something else before coercing it to an integer, or use the &lt;code&gt;Random.nextInt(n)&lt;/code&gt; method.
 &lt;/p&gt;</description>
     <tag>correctness</tag>
     <tag>bug</tag>
@@ -874,7 +889,7 @@ public boolean equals(Object o) {
 &lt;/pre&gt;
 
 &lt;p&gt;This is considered bad practice, as it makes it very hard to implement an equals method that
-is symmetric and transitive. Without those properties, very unexpected behavoirs are possible.
+is symmetric and transitive. Without those properties, very unexpected behaviors are possible.
 &lt;/p&gt;</description>
     <tag>bad-practice</tag>
   </rule>
@@ -1018,7 +1033,7 @@ public boolean equals(Object o) { return this == o; }
     A large String constant is duplicated across multiple class files.
     This is likely because a final field is initialized to a String constant, and the Java language
     mandates that all references to a final field from other classes be inlined into
-that classfile. See &lt;a href="http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6447475"&gt;JDK bug 6447475&lt;/a&gt;
+that classfile. See &lt;a href="http://bugs.java.com/bugdatabase/view_bug.do?bug_id=6447475"&gt;JDK bug 6447475&lt;/a&gt;
     for a description of an occurrence of this bug in the JDK and how resolving it reduced
     the size of the JDK by 1 megabyte.
 &lt;/p&gt;</description>
@@ -1248,7 +1263,7 @@ but can be accessed in a way that seems to violate those annotations.&lt;/p&gt;<
   <rule key='MSF_MUTABLE_SERVLET_FIELD' priority='MAJOR'>
     <name>Multi-threading - Mutable servlet field</name>
     <configKey>MSF_MUTABLE_SERVLET_FIELD</configKey>
-    <description>&lt;p&gt;A web server generally only creates one instance of servlet or jsp class (i.e., treats
+    <description>&lt;p&gt;A web server generally only creates one instance of servlet or JSP class (i.e., treats
 the class as a Singleton),
 and will
 have multiple threads invoke methods on that instance to service multiple
@@ -1385,8 +1400,8 @@ can result in errors if the left-hand side guards cases
 when evaluating the right-hand side can generate an error.
 &lt;/p&gt;
 
-&lt;p&gt;See &lt;a href="http://java.sun.com/docs/books/jls/third_edition/html/expressions.html#15.22.2"&gt;the Java
-Language Specification&lt;/a&gt; for details
+&lt;p&gt;See &lt;a href="https://docs.oracle.com/javase/specs/jls/se7/html/jls-15.html#jls-15.22.2"&gt;the Java
+Language Specification&lt;/a&gt; for details.
 
 &lt;/p&gt;</description>
     <tag>style</tag>
@@ -1403,8 +1418,8 @@ knowing the left-hand side. This can be less efficient and
 can result in errors if the left-hand side guards cases
 when evaluating the right-hand side can generate an error.
 
-&lt;p&gt;See &lt;a href="http://java.sun.com/docs/books/jls/third_edition/html/expressions.html#15.22.2"&gt;the Java
-Language Specification&lt;/a&gt; for details
+&lt;p&gt;See &lt;a href="https://docs.oracle.com/javase/specs/jls/se7/html/jls-15.html#jls-15.22.2"&gt;the Java
+Language Specification&lt;/a&gt; for details.
 
 &lt;/p&gt;</description>
     <tag>style</tag>
@@ -1460,7 +1475,7 @@ This not necessarily a bug, but is worth examining
   <rule key='UR_UNINIT_READ_CALLED_FROM_SUPER_CONSTRUCTOR' priority='MAJOR'>
     <name>Correctness - Uninitialized read of field method called from constructor of superclass</name>
     <configKey>UR_UNINIT_READ_CALLED_FROM_SUPER_CONSTRUCTOR</configKey>
-    <description>&lt;p&gt; This method is invoked in the constructor of of the superclass. At this point,
+    <description>&lt;p&gt; This method is invoked in the constructor of the superclass. At this point,
     the fields of the class have not yet initialized.&lt;/p&gt;
 &lt;p&gt;To make this more concrete, consider the following classes:&lt;/p&gt;
 &lt;pre&gt;abstract class A {
@@ -1483,7 +1498,7 @@ class B extends A {
 the constructor for the &lt;code&gt;A&lt;/code&gt; class is invoked
 &lt;em&gt;before&lt;/em&gt; the constructor for &lt;code&gt;B&lt;/code&gt; sets &lt;code&gt;value&lt;/code&gt;.
 Thus, when the constructor for &lt;code&gt;A&lt;/code&gt; invokes &lt;code&gt;getValue&lt;/code&gt;,
-an uninitialized value is read for &lt;code&gt;value&lt;/code&gt;
+an uninitialized value is read for &lt;code&gt;value&lt;/code&gt;.
 &lt;/p&gt;</description>
     <tag>correctness</tag>
     <tag>bug</tag>
@@ -1545,7 +1560,7 @@ private static String LOCK = "LOCK";
   synchronized(LOCK) { ...}
 ...
 &lt;/pre&gt;
-&lt;p&gt;Constant Strings are interned and shared across all other classes loaded by the JVM. Thus, this could
+&lt;p&gt;Constant Strings are interned and shared across all other classes loaded by the JVM. Thus, this code
 is locking on something that other code might also be locking. This could result in very strange and hard to diagnose
 blocking and deadlock behavior. See &lt;a href="http://www.javalobby.org/java/forums/t96352.html"&gt;http://www.javalobby.org/java/forums/t96352.html&lt;/a&gt; and &lt;a href="http://jira.codehaus.org/browse/JETTY-352"&gt;http://jira.codehaus.org/browse/JETTY-352&lt;/a&gt;.
 &lt;/p&gt;
@@ -1556,7 +1571,7 @@ blocking and deadlock behavior. See &lt;a href="http://www.javalobby.org/java/fo
   <rule key='DL_SYNCHRONIZATION_ON_BOOLEAN' priority='MAJOR'>
     <name>Multi-threading - Synchronization on Boolean</name>
     <configKey>DL_SYNCHRONIZATION_ON_BOOLEAN</configKey>
-    <description>&lt;p&gt; The code synchronizes on a boxed primitive constant, such as an Boolean.&lt;/p&gt;
+    <description>&lt;p&gt; The code synchronizes on a boxed primitive constant, such as a Boolean.&lt;/p&gt;
 &lt;pre&gt;
 private static Boolean inited = Boolean.FALSE;
 ...
@@ -1569,7 +1584,7 @@ private static Boolean inited = Boolean.FALSE;
 ...
 &lt;/pre&gt;
 &lt;p&gt;Since there normally exist only two Boolean objects, this code could be synchronizing on the same object as other, unrelated code, leading to unresponsiveness
-and possible deadlock&lt;/p&gt;
+and possible deadlock.&lt;/p&gt;
 &lt;p&gt;See CERT &lt;a href="https://www.securecoding.cert.org/confluence/display/java/CON08-J.+Do+not+synchronize+on+objects+that+may+be+reused"&gt;CON08-J. Do not synchronize on objects that may be reused&lt;/a&gt; for more information.&lt;/p&gt;</description>
     <tag>multi-threading</tag>
     <tag>bug</tag>
@@ -1614,7 +1629,7 @@ private static Integer count = 0;
 &lt;/pre&gt;
 &lt;p&gt;Since Integer objects can be cached and shared,
 this code could be synchronizing on the same object as other, unrelated code, leading to unresponsiveness
-and possible deadlock&lt;/p&gt;
+and possible deadlock.&lt;/p&gt;
 &lt;p&gt;See CERT &lt;a href="https://www.securecoding.cert.org/confluence/display/java/CON08-J.+Do+not+synchronize+on+objects+that+may+be+reused"&gt;CON08-J. Do not synchronize on objects that may be reused&lt;/a&gt; for more information.&lt;/p&gt;</description>
     <tag>multi-threading</tag>
     <tag>bug</tag>
@@ -1822,7 +1837,7 @@ could be changed by malicious code or
 An inner class is invoking a method that could be resolved to either a inherited method or a method defined in an outer class.
 For example, you invoke &lt;code&gt;foo(17)&lt;/code&gt;, which is defined in both a superclass and in an outer method.
 By the Java semantics,
-it will be resolved to invoke the inherited method, but this may not be want
+it will be resolved to invoke the inherited method, but this may not be what
 you intend.
 &lt;/p&gt;
 &lt;p&gt;If you really intend to invoke the inherited method,
@@ -2518,15 +2533,15 @@ Common false-positive cases include:&lt;/p&gt;
   <rule key='UC_USELESS_CONDITION' priority='INFO'>
     <name>Style - Condition has no effect</name>
     <configKey>UC_USELESS_CONDITION</configKey>
-    <description>&lt;p&gt;This condition always produces the same result as the value of the involved variable was narrowed before. 
-Probably something else was meant or condition can be removed.&lt;/p&gt;</description>
+    <description>&lt;p&gt;This condition always produces the same result as the value of the involved variable that was narrowed before.
+Probably something else was meant or the condition can be removed.&lt;/p&gt;</description>
     <tag>style</tag>
   </rule>
   <rule key='UC_USELESS_CONDITION_TYPE' priority='INFO'>
     <name>Style - Condition has no effect due to the variable type</name>
     <configKey>UC_USELESS_CONDITION_TYPE</configKey>
     <description>&lt;p&gt;This condition always produces the same result due to the type range of the involved variable. 
-Probably something else was meant or condition can be removed.&lt;/p&gt;</description>
+Probably something else was meant or the condition can be removed.&lt;/p&gt;</description>
     <tag>style</tag>
   </rule>
   <rule key='UC_USELESS_OBJECT' priority='INFO'>
@@ -3012,6 +3027,23 @@ both be definitely null.&lt;/p&gt;</description>
 known to be null.&lt;/p&gt;</description>
     <tag>style</tag>
   </rule>
+  <rule key='RCN_REDUNDANT_CHECKED_NULL_COMPARISON' priority='INFO'>
+    <name>Experimental - Redundant comparison to null of previously checked value</name>
+    <configKey>RCN_REDUNDANT_CHECKED_NULL_COMPARISON</configKey>
+    <description>&lt;p&gt; This method contains a redundant comparison of a reference value
+to null. Two types of redundant comparison are reported:
+&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt; Both values compared are definitely null&lt;/li&gt;
+&lt;li&gt; One value is definitely null and the other is definitely not null&lt;/li&gt;
+&lt;/ul&gt;
+
+&lt;p&gt; This particular warning generally indicates that a
+value known not to be null was checked against null.
+While the check is not necessary, it may simply be a case
+of defensive programming.&lt;/p&gt;</description>
+    <tag>experimental</tag>
+  </rule>
   <rule key='UL_UNRELEASED_LOCK' priority='MAJOR'>
     <name>Multi-threading - Method does not release lock on all paths</name>
     <configKey>UL_UNRELEASED_LOCK</configKey>
@@ -3083,7 +3115,7 @@ Normally, there are only two Boolean values (Boolean.TRUE and Boolean.FALSE),
 but it is possible to create other Boolean objects using the &lt;code&gt;new Boolean(b)&lt;/code&gt;
 constructor. It is best to avoid such objects, but if they do exist,
 then checking Boolean objects for equality using == or != will give results
-than are different than you would get using &lt;code&gt;.equals(...)&lt;/code&gt;
+than are different than you would get using &lt;code&gt;.equals(...)&lt;/code&gt;.
 &lt;/p&gt;</description>
     <tag>bad-practice</tag>
   </rule>
@@ -3295,7 +3327,7 @@ a logic error.  Make sure that you are comparing the right things.
     <name>Correctness - Double.longBitsToDouble invoked on an int</name>
     <configKey>DMI_LONG_BITS_TO_DOUBLE_INVOKED_ON_INT</configKey>
     <description>&lt;p&gt; The Double.longBitsToDouble method is invoked, but a 32 bit int value is passed
-    as an argument. This almostly certainly is not intended and is unlikely
+    as an argument. This almost certainly is not intended and is unlikely
     to give the intended result.
 &lt;/p&gt;</description>
     <tag>correctness</tag>
@@ -3332,7 +3364,7 @@ number; the values are too easily guessable. You should strongly consider using 
     <description>&lt;p&gt; This code generates a random signed integer and then computes
 the absolute value of that random integer.  If the number returned by the random number
 generator is &lt;code&gt;Integer.MIN_VALUE&lt;/code&gt;, then the result will be negative as well (since
-&lt;code&gt;Math.abs(Integer.MIN_VALUE) == Integer.MIN_VALUE&lt;/code&gt;). (Same problem arised for long values as well).
+&lt;code&gt;Math.abs(Integer.MIN_VALUE) == Integer.MIN_VALUE&lt;/code&gt;). (Same problem arises for long values as well).
 &lt;/p&gt;</description>
     <tag>correctness</tag>
     <tag>bug</tag>
@@ -3373,11 +3405,11 @@ can also be negative. &lt;/p&gt;
 you may need to change your code.
 If you know the divisor is a power of 2,
 you can use a bitwise and operator instead (i.e., instead of
-using &lt;code&gt;x.hashCode()%n&lt;/code&gt;, use &lt;code&gt;x.hashCode()&amp;amp;(n-1)&lt;/code&gt;.
+using &lt;code&gt;x.hashCode()%n&lt;/code&gt;, use &lt;code&gt;x.hashCode()&amp;amp;(n-1)&lt;/code&gt;).
 This is probably faster than computing the remainder as well.
 If you don't know that the divisor is a power of 2, take the absolute
 value of the result of the remainder operation (i.e., use
-&lt;code&gt;Math.abs(x.hashCode()%n)&lt;/code&gt;
+&lt;code&gt;Math.abs(x.hashCode()%n)&lt;/code&gt;).
 &lt;/p&gt;</description>
     <tag>style</tag>
   </rule>
@@ -3395,7 +3427,7 @@ value of the result of the remainder operation (i.e., use
     <description>&lt;p&gt; Signed bytes can only have a value in the range -128 to 127. Comparing
 a signed byte with a value outside that range is vacuous and likely to be incorrect.
 To convert a signed byte &lt;code&gt;b&lt;/code&gt; to an unsigned value in the range 0..255,
-use &lt;code&gt;0xff &amp;amp; b&lt;/code&gt;
+use &lt;code&gt;0xff &amp;amp; b&lt;/code&gt;.
 &lt;/p&gt;</description>
     <tag>correctness</tag>
     <tag>bug</tag>
@@ -3405,7 +3437,7 @@ use &lt;code&gt;0xff &amp;amp; b&lt;/code&gt;
     <configKey>INT_BAD_COMPARISON_WITH_INT_VALUE</configKey>
     <description>&lt;p&gt; This code compares an int value with a long constant that is outside
 the range of values that can be represented as an int value.
-This comparison is vacuous and possibily to be incorrect.
+This comparison is vacuous and possibly to be incorrect.
 &lt;/p&gt;</description>
     <tag>correctness</tag>
     <tag>bug</tag>
@@ -3441,7 +3473,7 @@ Did you mean (exp &amp;amp; 1) or (exp % 2) instead?
     <description>&lt;p&gt; Loads a byte value (e.g., a value loaded from a byte array or returned by a method
 with return type byte)  and performs a bitwise OR with
 that value. Byte values are sign extended to 32 bits
-before any any bitwise operations are performed on the value.
+before any bitwise operations are performed on the value.
 Thus, if &lt;code&gt;b[0]&lt;/code&gt; contains the value &lt;code&gt;0xff&lt;/code&gt;, and
 &lt;code&gt;x&lt;/code&gt; is initially 0, then the code
 &lt;code&gt;((x &amp;lt;&amp;lt; 8) | b[0])&lt;/code&gt;  will sign extend &lt;code&gt;0xff&lt;/code&gt;
@@ -3470,7 +3502,7 @@ for(int i = 0; i &amp;lt; 4; i++)
     <configKey>BIT_ADD_OF_SIGNED_BYTE</configKey>
     <description>&lt;p&gt; Adds a byte value and a value which is known to have the 8 lower bits clear.
 Values loaded from a byte array are sign extended to 32 bits
-before any any bitwise operations are performed on the value.
+before any bitwise operations are performed on the value.
 Thus, if &lt;code&gt;b[0]&lt;/code&gt; contains the value &lt;code&gt;0xff&lt;/code&gt;, and
 &lt;code&gt;x&lt;/code&gt; is initially 0, then the code
 &lt;code&gt;((x &amp;lt;&amp;lt; 8) + b[0])&lt;/code&gt;  will sign extend &lt;code&gt;0xff&lt;/code&gt;
@@ -3507,32 +3539,24 @@ This may indicate a logic error or typo.&lt;/p&gt;</description>
   <rule key='BIT_SIGNED_CHECK' priority='MAJOR'>
     <name>Bad practice - Check for sign of bitwise operation</name>
     <configKey>BIT_SIGNED_CHECK</configKey>
-    <description>&lt;p&gt; This method compares an expression such as&lt;/p&gt;
-&lt;pre&gt;((event.detail &amp;amp; SWT.SELECTED) &amp;gt; 0)&lt;/pre&gt;.
-&lt;p&gt;Using bit arithmetic and then comparing with the greater than operator can
+    <description>&lt;p&gt; This method compares an expression such as
+&lt;code&gt;((event.detail &amp;amp; SWT.SELECTED) &amp;gt; 0)&lt;/code&gt;.
+Using bit arithmetic and then comparing with the greater than operator can
 lead to unexpected results (of course depending on the value of
 SWT.SELECTED). If SWT.SELECTED is a negative number, this is a candidate
 for a bug. Even when SWT.SELECTED is not negative, it seems good practice
 to use '!= 0' instead of '&amp;gt; 0'.
-&lt;/p&gt;
-&lt;p&gt;
-&lt;em&gt;Boris Bokowski&lt;/em&gt;
 &lt;/p&gt;</description>
     <tag>bad-practice</tag>
   </rule>
   <rule key='BIT_SIGNED_CHECK_HIGH_BIT' priority='MAJOR'>
-    <name>Correctness - Check for sign of bitwise operation</name>
+    <name>Correctness - Check for sign of bitwise operation involving negative number</name>
     <configKey>BIT_SIGNED_CHECK_HIGH_BIT</configKey>
-    <description>&lt;p&gt; This method compares an expression such as&lt;/p&gt;
-&lt;pre&gt;((event.detail &amp;amp; SWT.SELECTED) &amp;gt; 0)&lt;/pre&gt;.
-&lt;p&gt;Using bit arithmetic and then comparing with the greater than operator can
-lead to unexpected results (of course depending on the value of
-SWT.SELECTED). If SWT.SELECTED is a negative number, this is a candidate
-for a bug. Even when SWT.SELECTED is not negative, it seems good practice
+    <description>&lt;p&gt; This method compares a bitwise expression such as
+&lt;code&gt;((val &amp;amp; CONSTANT) &amp;gt; 0)&lt;/code&gt; where CONSTANT is the negative number.
+Using bit arithmetic and then comparing with the greater than operator can
+lead to unexpected results. This comparison is unlikely to work as expected. The good practice is
 to use '!= 0' instead of '&amp;gt; 0'.
-&lt;/p&gt;
-&lt;p&gt;
-&lt;em&gt;Boris Bokowski&lt;/em&gt;
 &lt;/p&gt;</description>
     <tag>correctness</tag>
     <tag>bug</tag>
@@ -3540,7 +3564,7 @@ to use '!= 0' instead of '&amp;gt; 0'.
   <rule key='BIT_AND_ZZ' priority='MAJOR'>
     <name>Correctness - Check to see if ((...) &amp; 0) == 0</name>
     <configKey>BIT_AND_ZZ</configKey>
-    <description>&lt;p&gt; This method compares an expression of the form (e &amp;amp; 0) to 0,
+    <description>&lt;p&gt; This method compares an expression of the form &lt;code&gt;(e &amp;amp; 0)&lt;/code&gt; to 0,
 which will always compare equal.
 This may indicate a logic error or typo.&lt;/p&gt;</description>
     <tag>correctness</tag>
@@ -3549,14 +3573,17 @@ This may indicate a logic error or typo.&lt;/p&gt;</description>
   <rule key='BIT_IOR' priority='MAJOR'>
     <name>Correctness - Incompatible bit masks</name>
     <configKey>BIT_IOR</configKey>
-    <description>&lt;p&gt; This method compares an expression of the form (e | C) to D.
+    <description>&lt;p&gt; This method compares an expression of the form &lt;code&gt;(e | C)&lt;/code&gt; to D.
 which will always compare unequal
 due to the specific values of constants C and D.
 This may indicate a logic error or typo.&lt;/p&gt;
 
 &lt;p&gt; Typically, this bug occurs because the code wants to perform
 a membership test in a bit set, but uses the bitwise OR
-operator ("|") instead of bitwise AND ("&amp;amp;").&lt;/p&gt;</description>
+operator ("|") instead of bitwise AND ("&amp;amp;").&lt;/p&gt;
+
+&lt;p&gt;Also such bug may appear in expressions like &lt;code&gt;(e &amp;amp; A | B) == C&lt;/code&gt;
+which is parsed like &lt;code&gt;((e &amp;amp; A) | B) == C&lt;/code&gt; while &lt;code&gt;(e &amp;amp; (A | B)) == C&lt;/code&gt; was intended.&lt;/p&gt;</description>
     <tag>correctness</tag>
     <tag>bug</tag>
   </rule>
@@ -3594,7 +3621,7 @@ For more information, see the
     <description>&lt;p&gt; This method contains an unsynchronized lazy initialization of a static field.
 After the field is set, the object stored into that location is further updated or accessed.
 The setting of the field is visible to other threads as soon as it is set. If the
-futher accesses in the method that set the field serve to initialize the object, then
+further accesses in the method that set the field serve to initialize the object, then
 you have a &lt;em&gt;very serious&lt;/em&gt; multithreading bug, unless something else prevents
 any other thread from accessing the stored object until it is fully initialized.
 &lt;/p&gt;
@@ -3844,7 +3871,7 @@ or
   <rule key='IJU_NO_TESTS' priority='MAJOR'>
     <name>Correctness - TestCase has no tests</name>
     <configKey>IJU_NO_TESTS</configKey>
-    <description>&lt;p&gt; Class is a JUnit TestCase but has not implemented any test methods&lt;/p&gt;</description>
+    <description>&lt;p&gt; Class is a JUnit TestCase but has not implemented any test methods.&lt;/p&gt;</description>
     <tag>correctness</tag>
     <tag>bug</tag>
   </rule>
@@ -4025,12 +4052,12 @@ Please verify that this statement does the right thing.
     <configKey>DLS_DEAD_STORE_OF_CLASS_LITERAL</configKey>
     <description>&lt;p&gt;
 This instruction assigns a class literal to a variable and then never uses it.
-&lt;a href="//java.sun.com/j2se/1.5.0/compatibility.html#literal"&gt;The behavior of this differs in Java 1.4 and in Java 5.&lt;/a&gt;
+&lt;a href="http://www.oracle.com/technetwork/java/javase/compatibility-137462.html#literal"&gt;The behavior of this differs in Java 1.4 and in Java 5.&lt;/a&gt;
 In Java 1.4 and earlier, a reference to &lt;code&gt;Foo.class&lt;/code&gt; would force the static initializer
 for &lt;code&gt;Foo&lt;/code&gt; to be executed, if it has not been executed already.
 In Java 5 and later, it does not.
 &lt;/p&gt;
-&lt;p&gt;See Sun's &lt;a href="//java.sun.com/j2se/1.5.0/compatibility.html#literal"&gt;article on Java SE compatibility&lt;/a&gt;
+&lt;p&gt;See Sun's &lt;a href="http://www.oracle.com/technetwork/java/javase/compatibility-137462.html#literal"&gt;article on Java SE compatibility&lt;/a&gt;
 for more details and examples, and suggestions on how to force class initialization in Java 5.
 &lt;/p&gt;</description>
     <tag>correctness</tag>
@@ -4426,8 +4453,8 @@ For example,
     <name>Bad practice - Format string should use %n rather than \n</name>
     <configKey>VA_FORMAT_STRING_USES_NEWLINE</configKey>
     <description>&lt;p&gt;
-This format string include a newline character (\n). In format strings, it is generally
- preferable better to use %n, which will produce the platform-specific line separator.
+This format string includes a newline character (\n). In format strings, it is generally
+ preferable to use %n, which will produce the platform-specific line separator.
 &lt;/p&gt;</description>
     <tag>bad-practice</tag>
   </rule>
@@ -4435,7 +4462,7 @@ This format string include a newline character (\n). In format strings, it is ge
     <name>Correctness - The type of a supplied argument doesn't match format specifier</name>
     <configKey>VA_FORMAT_STRING_BAD_CONVERSION</configKey>
     <description>&lt;p&gt;
-One of the arguments is uncompatible with the corresponding format string specifier.
+One of the arguments is incompatible with the corresponding format string specifier.
 As a result, this will generate a runtime exception when executed.
 For example, &lt;code&gt;String.format("%d", "1")&lt;/code&gt; will generate an exception, since
 the String "1" is incompatible with the format specifier %d.
@@ -4628,7 +4655,7 @@ since the Collection object has no reference to the declared generic type of the
 &lt;p&gt;The correct way to do get an array of a specific type from a collection is to use
   &lt;code&gt;c.toArray(new String[]);&lt;/code&gt;
   or &lt;code&gt;c.toArray(new String[c.size()]);&lt;/code&gt; (the latter is slightly more efficient).
-&lt;p&gt;There is one common/known exception exception to this. The &lt;code&gt;toArray()&lt;/code&gt;
+&lt;p&gt;There is one common/known exception to this. The &lt;code&gt;toArray()&lt;/code&gt;
 method of lists returned by &lt;code&gt;Arrays.asList(...)&lt;/code&gt; will return a covariantly
 typed array. For example, &lt;code&gt;Arrays.asArray(new String[] { "a" }).toArray()&lt;/code&gt;
 will return a &lt;code&gt;String []&lt;/code&gt;. FindBugs attempts to detect and suppress
@@ -4748,7 +4775,7 @@ executed.
 The code here uses &lt;code&gt;File.separator&lt;/code&gt;
 where a regular expression is required. This will fail on Windows
 platforms, where the &lt;code&gt;File.separator&lt;/code&gt; is a backslash, which is interpreted in a
-regular expression as an escape character. Amoung other options, you can just use
+regular expression as an escape character. Among other options, you can just use
 &lt;code&gt;File.separatorChar=='\\' ? "\\\\" : File.separator&lt;/code&gt; instead of
 &lt;code&gt;File.separator&lt;/code&gt;
 
@@ -4819,7 +4846,7 @@ i % 60 * 1000 is (i % 60) * 1000, not i % (60 * 1000).
     <configKey>DMI_INVOKING_HASHCODE_ON_ARRAY</configKey>
     <description>&lt;p&gt;
 The code invokes hashCode on an array. Calling hashCode on
-an array returns the same value as System.identityHashCode, and ingores
+an array returns the same value as System.identityHashCode, and ignores
 the contents and length of the array. If you need a hashCode that
 depends on the contents of an array &lt;code&gt;a&lt;/code&gt;,
 use &lt;code&gt;java.util.Arrays.hashCode(a)&lt;/code&gt;.
@@ -4861,7 +4888,7 @@ can use an unsigned right shift instead. In other words, rather that using &lt;c
 use &lt;code&gt;(low+high) &amp;gt;&amp;gt;&amp;gt; 1&lt;/code&gt;
 &lt;/p&gt;
 &lt;p&gt;This bug exists in many earlier implementations of binary search and merge sort.
-Martin Buchholz &lt;a href="http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6412541"&gt;found and fixed it&lt;/a&gt;
+Martin Buchholz &lt;a href="http://bugs.java.com/bugdatabase/view_bug.do?bug_id=6412541"&gt;found and fixed it&lt;/a&gt;
 in the JDK libraries, and Joshua Bloch
 &lt;a href="http://googleresearch.blogspot.com/2006/06/extra-extra-read-all-about-it-nearly.html"&gt;widely
 publicized the bug pattern&lt;/a&gt;.
@@ -5127,25 +5154,25 @@ for some collections, might throw a &lt;code&gt;ConcurrentModificationException&
   <rule key='STCAL_STATIC_CALENDAR_INSTANCE' priority='MAJOR'>
     <name>Multi-threading - Static Calendar field</name>
     <configKey>STCAL_STATIC_CALENDAR_INSTANCE</configKey>
-    <description>&lt;p&gt;Even though the JavaDoc does not contain a hint about it, Calendars are inherently unsafe for multihtreaded use.
+    <description>&lt;p&gt;Even though the JavaDoc does not contain a hint about it, Calendars are inherently unsafe for multithreaded use.
 Sharing a single instance across thread boundaries without proper synchronization will result in erratic behavior of the
 application. Under 1.4 problems seem to surface less often than under Java 5 where you will probably see
 random ArrayIndexOutOfBoundsExceptions or IndexOutOfBoundsExceptions in sun.util.calendar.BaseCalendar.getCalendarDateFromFixedDate().&lt;/p&gt;
 &lt;p&gt;You may also experience serialization problems.&lt;/p&gt;
 &lt;p&gt;Using an instance field is recommended.&lt;/p&gt;
-&lt;p&gt;For more information on this see &lt;a href="http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6231579"&gt;Sun Bug #6231579&lt;/a&gt;
-and &lt;a href="http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6178997"&gt;Sun Bug #6178997&lt;/a&gt;.&lt;/p&gt;</description>
+&lt;p&gt;For more information on this see &lt;a href="http://bugs.java.com/bugdatabase/view_bug.do?bug_id=6231579"&gt;JDK Bug #6231579&lt;/a&gt;
+and &lt;a href="http://bugs.java.com/bugdatabase/view_bug.do?bug_id=6178997"&gt;JDK Bug #6178997&lt;/a&gt;.&lt;/p&gt;</description>
     <tag>multi-threading</tag>
     <tag>bug</tag>
   </rule>
   <rule key='STCAL_INVOKE_ON_STATIC_CALENDAR_INSTANCE' priority='MAJOR'>
     <name>Multi-threading - Call to static Calendar</name>
     <configKey>STCAL_INVOKE_ON_STATIC_CALENDAR_INSTANCE</configKey>
-    <description>&lt;p&gt;Even though the JavaDoc does not contain a hint about it, Calendars are inherently unsafe for multihtreaded use.
+    <description>&lt;p&gt;Even though the JavaDoc does not contain a hint about it, Calendars are inherently unsafe for multithreaded use.
 The detector has found a call to an instance of Calendar that has been obtained via a static
-field. This looks suspicous.&lt;/p&gt;
-&lt;p&gt;For more information on this see &lt;a href="http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6231579"&gt;Sun Bug #6231579&lt;/a&gt;
-and &lt;a href="http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6178997"&gt;Sun Bug #6178997&lt;/a&gt;.&lt;/p&gt;</description>
+field. This looks suspicious.&lt;/p&gt;
+&lt;p&gt;For more information on this see &lt;a href="http://bugs.java.com/bugdatabase/view_bug.do?bug_id=6231579"&gt;JDK Bug #6231579&lt;/a&gt;
+and &lt;a href="http://bugs.java.com/bugdatabase/view_bug.do?bug_id=6178997"&gt;JDK Bug #6178997&lt;/a&gt;.&lt;/p&gt;</description>
     <tag>multi-threading</tag>
     <tag>bug</tag>
   </rule>
@@ -5157,8 +5184,8 @@ Sharing a single instance across thread boundaries without proper synchronizatio
 application.&lt;/p&gt;
 &lt;p&gt;You may also experience serialization problems.&lt;/p&gt;
 &lt;p&gt;Using an instance field is recommended.&lt;/p&gt;
-&lt;p&gt;For more information on this see &lt;a href="http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6231579"&gt;Sun Bug #6231579&lt;/a&gt;
-and &lt;a href="http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6178997"&gt;Sun Bug #6178997&lt;/a&gt;.&lt;/p&gt;</description>
+&lt;p&gt;For more information on this see &lt;a href="http://bugs.java.com/bugdatabase/view_bug.do?bug_id=6231579"&gt;JDK Bug #6231579&lt;/a&gt;
+and &lt;a href="http://bugs.java.com/bugdatabase/view_bug.do?bug_id=6178997"&gt;JDK Bug #6178997&lt;/a&gt;.&lt;/p&gt;</description>
     <tag>multi-threading</tag>
     <tag>bug</tag>
   </rule>
@@ -5167,9 +5194,9 @@ and &lt;a href="http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6178997"&gt;S
     <configKey>STCAL_INVOKE_ON_STATIC_DATE_FORMAT_INSTANCE</configKey>
     <description>&lt;p&gt;As the JavaDoc states, DateFormats are inherently unsafe for multithreaded use.
 The detector has found a call to an instance of DateFormat that has been obtained via a static
-field. This looks suspicous.&lt;/p&gt;
-&lt;p&gt;For more information on this see &lt;a href="http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6231579"&gt;Sun Bug #6231579&lt;/a&gt;
-and &lt;a href="http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6178997"&gt;Sun Bug #6178997&lt;/a&gt;.&lt;/p&gt;</description>
+field. This looks suspicious.&lt;/p&gt;
+&lt;p&gt;For more information on this see &lt;a href="http://bugs.java.com/bugdatabase/view_bug.do?bug_id=6231579"&gt;JDK Bug #6231579&lt;/a&gt;
+and &lt;a href="http://bugs.java.com/bugdatabase/view_bug.do?bug_id=6178997"&gt;JDK Bug #6178997&lt;/a&gt;.&lt;/p&gt;</description>
     <tag>multi-threading</tag>
     <tag>bug</tag>
   </rule>
@@ -5363,11 +5390,96 @@ public @NonNegative Integer example(@Negative Integer value) {
     <tag>multi-threading</tag>
     <tag>bug</tag>
   </rule>
+  <rule key='OBL_UNSATISFIED_OBLIGATION' priority='INFO'>
+    <name>Experimental - Method may fail to clean up stream or resource</name>
+    <configKey>OBL_UNSATISFIED_OBLIGATION</configKey>
+    <description>&lt;p&gt;
+          This method may fail to clean up (close, dispose of) a stream,
+          database object, or other
+          resource requiring an explicit cleanup operation.
+          &lt;/p&gt;
+
+          &lt;p&gt;
+          In general, if a method opens a stream or other resource,
+          the method should use a try/finally block to ensure that
+          the stream or resource is cleaned up before the method
+          returns.
+          &lt;/p&gt;
+
+          &lt;p&gt;
+          This bug pattern is essentially the same as the
+          OS_OPEN_STREAM and ODR_OPEN_DATABASE_RESOURCE
+          bug patterns, but is based on a different
+          (and hopefully better) static analysis technique.
+          We are interested is getting feedback about the
+          usefulness of this bug pattern.
+          To send feedback:
+          &lt;/p&gt;
+          &lt;ul&gt;
+            &lt;li&gt;file an issue: &lt;a href="https://github.com/spotbugs/spotbugs/issues"&gt;https://github.com/spotbugs/spotbugs/issues&lt;/a&gt;&lt;/li&gt;
+          &lt;/ul&gt;
+
+          &lt;p&gt;
+          In particular,
+          the false-positive suppression heuristics for this
+          bug pattern have not been extensively tuned, so
+          reports about false positives are helpful to us.
+          &lt;/p&gt;
+
+          &lt;p&gt;
+          See Weimer and Necula, &lt;i&gt;Finding and Preventing Run-Time Error Handling Mistakes&lt;/i&gt;, for
+          a description of the analysis technique.
+          &lt;/p&gt;</description>
+    <tag>experimental</tag>
+  </rule>
+  <rule key='OBL_UNSATISFIED_OBLIGATION_EXCEPTION_EDGE' priority='INFO'>
+    <name>Experimental - Method may fail to clean up stream or resource on checked exception</name>
+    <configKey>OBL_UNSATISFIED_OBLIGATION_EXCEPTION_EDGE</configKey>
+    <description>&lt;p&gt;
+          This method may fail to clean up (close, dispose of) a stream,
+          database object, or other
+          resource requiring an explicit cleanup operation.
+          &lt;/p&gt;
+
+          &lt;p&gt;
+          In general, if a method opens a stream or other resource,
+          the method should use a try/finally block to ensure that
+          the stream or resource is cleaned up before the method
+          returns.
+          &lt;/p&gt;
+
+          &lt;p&gt;
+          This bug pattern is essentially the same as the
+          OS_OPEN_STREAM and ODR_OPEN_DATABASE_RESOURCE
+          bug patterns, but is based on a different
+          (and hopefully better) static analysis technique.
+          We are interested is getting feedback about the
+          usefulness of this bug pattern.
+          To send feedback, either:
+          &lt;/p&gt;
+          &lt;ul&gt;
+            &lt;li&gt;send email to findbugs@cs.umd.edu&lt;/li&gt;
+            &lt;li&gt;file a bug report: &lt;a href="http://findbugs.sourceforge.net/reportingBugs.html"&gt;http://findbugs.sourceforge.net/reportingBugs.html&lt;/a&gt;&lt;/li&gt;
+          &lt;/ul&gt;
+
+          &lt;p&gt;
+          In particular,
+          the false-positive suppression heuristics for this
+          bug pattern have not been extensively tuned, so
+          reports about false positives are helpful to us.
+          &lt;/p&gt;
+
+          &lt;p&gt;
+          See Weimer and Necula, &lt;i&gt;Finding and Preventing Run-Time Error Handling Mistakes&lt;/i&gt;, for
+          a description of the analysis technique.
+          &lt;/p&gt;</description>
+    <tag>experimental</tag>
+  </rule>
   <rule key='FB_UNEXPECTED_WARNING' priority='MAJOR'>
     <name>Correctness - Unexpected/undesired warning from FindBugs</name>
     <configKey>FB_UNEXPECTED_WARNING</configKey>
     <description>&lt;p&gt;FindBugs generated a warning that, according to a @NoWarning annotated,
-            is unexpected or undesired&lt;/p&gt;</description>
+            is unexpected or undesired.&lt;/p&gt;</description>
     <tag>correctness</tag>
     <tag>bug</tag>
   </rule>
@@ -5375,7 +5487,7 @@ public @NonNegative Integer example(@Negative Integer value) {
     <name>Correctness - Missing expected or desired warning from FindBugs</name>
     <configKey>FB_MISSING_EXPECTED_WARNING</configKey>
     <description>&lt;p&gt;FindBugs didn't generate generated a warning that, according to a @ExpectedWarning annotated,
-            is expected or desired&lt;/p&gt;</description>
+            is expected or desired.&lt;/p&gt;</description>
     <tag>correctness</tag>
     <tag>bug</tag>
   </rule>
@@ -5391,6 +5503,38 @@ public @NonNegative Integer example(@Negative Integer value) {
         your program will behave incorrectly.</description>
     <tag>multi-threading</tag>
     <tag>bug</tag>
+  </rule>
+  <rule key='LG_LOST_LOGGER_DUE_TO_WEAK_REFERENCE' priority='INFO'>
+    <name>Experimental - Potential lost logger changes due to weak reference in OpenJDK</name>
+    <configKey>LG_LOST_LOGGER_DUE_TO_WEAK_REFERENCE</configKey>
+    <description>&lt;p&gt;OpenJDK introduces a potential incompatibility.
+ In particular, the java.util.logging.Logger behavior has
+  changed. Instead of using strong references, it now uses weak references
+  internally. That's a reasonable change, but unfortunately some code relies on
+  the old behavior - when changing logger configuration, it simply drops the
+  logger reference. That means that the garbage collector is free to reclaim
+  that memory, which means that the logger configuration is lost. For example,
+consider:
+&lt;/p&gt;
+
+&lt;pre&gt;public static void initLogging() throws Exception {
+ Logger logger = Logger.getLogger("edu.umd.cs");
+ logger.addHandler(new FileHandler()); // call to change logger configuration
+ logger.setUseParentHandlers(false); // another call to change logger configuration
+}&lt;/pre&gt;
+
+&lt;p&gt;The logger reference is lost at the end of the method (it doesn't
+escape the method), so if you have a garbage collection cycle just
+after the call to initLogging, the logger configuration is lost
+(because Logger only keeps weak references).&lt;/p&gt;
+
+&lt;pre&gt;public static void main(String[] args) throws Exception {
+ initLogging(); // adds a file handler to the logger
+ System.gc(); // logger configuration lost
+ Logger.getLogger("edu.umd.cs").info("Some message"); // this isn't logged to the file as expected
+}&lt;/pre&gt;
+&lt;p&gt;&lt;em&gt;Ulf Ochsenfahrt and Eric Fellheimer&lt;/em&gt;&lt;/p&gt;</description>
+    <tag>experimental</tag>
   </rule>
   <rule key='AT_OPERATION_SEQUENCE_ON_CONCURRENT_ABSTRACTION' priority='MAJOR'>
     <name>Multi-threading - Sequence of calls to concurrent abstraction may not be atomic</name>

--- a/src/test/java/org/sonar/plugins/findbugs/FbContribRulesDefinitionTest.java
+++ b/src/test/java/org/sonar/plugins/findbugs/FbContribRulesDefinitionTest.java
@@ -42,7 +42,7 @@ public class FbContribRulesDefinitionTest {
     assertThat(repository.language()).isEqualTo(Java.KEY);
 
     List<Rule> rules = repository.rules();
-    assertThat(rules).hasSize(FbContribRulesDefinition.RULE_COUNT);
+    assertThat(rules).hasSize(FbContribRulesDefinition.RULE_COUNT + FbContribRulesDefinition.DEACTIVED_RULE_COUNT);
 
     for (Rule rule : rules) {
       assertThat(rule.key()).isNotNull();

--- a/src/test/java/org/sonar/plugins/findbugs/FindbugsRulesDefinitionTest.java
+++ b/src/test/java/org/sonar/plugins/findbugs/FindbugsRulesDefinitionTest.java
@@ -42,7 +42,7 @@ public class FindbugsRulesDefinitionTest {
     assertThat(repository.language()).isEqualTo(Java.KEY);
 
     List<Rule> rules = repository.rules();
-    assertThat(rules).hasSize(FindbugsRulesDefinition.RULE_COUNT);
+    assertThat(rules).hasSize(FindbugsRulesDefinition.RULE_COUNT + FindbugsRulesDefinition.DEACTIVED_RULE_COUNT);
 
     List<String> rulesWithMissingSQALE = Lists.newLinkedList();
     for (Rule rule : rules) {


### PR DESCRIPTION
Experimental rules are currently not registered. This means that people
than not test test them. This leads to issues like #85.
It is important to note that this commit does not enable experimental
rules by default. They are still missing from all quality profiles.
If people want to test them they still have to create their own quality
profile with experimental rules.

This adds the following experimental rules

- SKIPPED_CLASS_TOO_BIG
- DP_DO_INSIDE_DO_PRIVILEDGED
- RCN_REDUNDANT_CHECKED_NULL_COMPARISON
- OBL_UNSATISFIED_OBLIGATION
- OBL_UNSATISFIED_OBLIGATION_EXCEPTION_EDGE
- LG_LOST_LOGGER_DUE_TO_WEAK_REFERENCE

This adds the following experimental contrib rules

- LO_EMBEDDED_SIMPLE_STRING_FORMAT_IN_FORMAT_STRING
- IOI_USE_OF_FILE_STREAM_CONSTRUCTORS