### PR TITLE
Update version information

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ Make sure that you compile your source code with debug information on (to get th
 Since version 3.0, the plugin embed FindBugs 3.0.0 which supports analysis of Java 8 bytecode but requires Java 1.7 to run (see Compatibility section). Please find below the compatibility matrix of the plugin.
 
 Findbugs Plugin version|Embedded Findbugs version|Embedded Findsecbugs version|Embedded FB-Contrib version|Minimal Java version
-----|-------|-------|-------|----
-2.4 | 2.0.3 | N/A   | 5.2.1 | 1.6
-3.0 | 3.0.0 | N/A   | 6.0.0 | 1.7
-3.2 | 3.0.1 | 1.3.0 | 6.0.0 | 1.7
-3.3 | 3.0.1 | 1.4.2 | 6.2.3 | 1.7
-3.4 | 3.0.1 | 1.4.6 | 6.6.1 | 1.8
-3.5 | 3.0.1 | 1.5.0 | 6.8.0 | 1.8
+-----------------------|-------------------------|----------------------------|---------------------------|--------------------
+2.4                    | 2.0.3                   | N/A                        | 5.2.1                     | 1.6
+3.0                    | 3.0.0                   | N/A                        | 6.0.0                     | 1.7
+3.2                    | 3.0.1                   | 1.3.0                      | 6.0.0                     | 1.7
+3.3                    | 3.0.1                   | 1.4.2                      | 6.2.3                     | 1.7
+3.4                    | 3.0.1                   | 1.4.6                      | 6.6.1                     | 1.8
+3.5                    | 3.1.0 RC1               | 1.6.0                      | 7.0.0                     | 1.8


### PR DESCRIPTION
After #90 and #97 the version information in the README was outdated.
To the exact the following versions were outdated:

- Embedded Findbugs version
- Embedded Findsecbugs version
- Embedded FB-Contrib version