### PR TITLE
Updated fbcontrib dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
 
     <sonar.version>5.6.6</sonar.version>
     <sonar-java.version>4.0</sonar-java.version>
-    <fbcontrib.version>7.0.0</fbcontrib.version>
+    <fbcontrib.version>7.0.3</fbcontrib.version>
     <findsecbugs.version>1.6.0</findsecbugs.version>
 
 


### PR DESCRIPTION
There is a BCEL issue that was fixed in fbcontrib 7.0.3:
https://github.com/mebigfatguy/fb-contrib/issues/205

It would be nice to upgrade this dependency in next sonar-findbugs release (3.6.0?).