### PR TITLE
Updating fb-contrib dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
 
     <sonar.version>5.6.6</sonar.version>
     <sonar-java.version>4.0</sonar-java.version>
-    <fbcontrib.version>7.0.3</fbcontrib.version>
+    <fbcontrib.version>7.0.3.sb</fbcontrib.version>
     <findsecbugs.version>1.6.0</findsecbugs.version>
 
 


### PR DESCRIPTION
fb-contrib dependency is different depending on wether you are using findbugs(7.0.3) or in this case, SpotBugs (7.0.3.sb).

The current Readme for fb-contrib states this explicitly in the beginning of the readme: https://github.com/mebigfatguy/fb-contrib

So, Setting dependency to fb-contrib 7.0.3.sb.
