### PR TITLE
change version 3.6.0 -> 3.6.1-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.sonarsource.sonar-findbugs-plugin</groupId>
   <artifactId>sonar-findbugs-plugin</artifactId>
-  <version>3.6.0</version>
+  <version>3.6.1-SNAPSHOT</version>
   <packaging>sonar-plugin</packaging>
 
   <name>SonarQube Findbugs Plugin</name>
@@ -52,7 +52,7 @@
 
     <sonar.version>5.6.6</sonar.version>
     <sonar-java.version>4.0</sonar-java.version>
-    <fbcontrib.version>7.0.3.sb</fbcontrib.version>
+    <fbcontrib.version>7.0.4.sb</fbcontrib.version>
     <findsecbugs.version>1.7.1</findsecbugs.version>
 
 
@@ -91,6 +91,10 @@
           <groupId>org.codehaus.sonar</groupId>
           <artifactId>sonar-plugin-api</artifactId>
         </exclusion>
+        <exclusion>
+        	<groupId>org.codehaus.sonar.sslr</groupId>
+        	<artifactId>sslr-core</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 
@@ -104,7 +108,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>10.0.1</version>
+      <version>17.0</version>
     </dependency>
 
     <dependency>
@@ -184,7 +188,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.8.47</version>
+      <version>2.10.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -219,7 +223,24 @@
       <groupId>org.sonarsource.sslr</groupId>
       <artifactId>sslr-core</artifactId>
       <version>1.22</version>
+      <exclusions>
+      	<exclusion>
+      		<groupId>cglib</groupId>
+      		<artifactId>cglib-nodep</artifactId>
+      	</exclusion>
+      </exclusions>
     </dependency>
+	<dependency>
+	    <groupId>cglib</groupId>
+	    <artifactId>cglib</artifactId>
+	    <version>3.2.5</version>
+	    <exclusions>
+	    	<exclusion>
+    			<groupId>org.ow2.asm</groupId>	    	
+	    	    <artifactId>asm</artifactId>
+	    	</exclusion>
+	    </exclusions>
+	</dependency>
 
   </dependencies>
 
@@ -245,7 +266,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.6.2</version>
+        <version>3.7.0</version>
         <configuration>
           <source>${jdk.min.version}</source>
           <target>${jdk.min.version}</target>


### PR DESCRIPTION
use cglib instead of cglib-nodep (to use ASM 6_BETA)
fbcontrib 7.0.3.sb -> 7.0.4.sb
multiple versions of sslr-core, exlude old codehaus version
guava 10.0.1 -> 17.0
mockito-core 2.8.47 -> 2.10.0
maven-compiler-plugin 3.6.2 -> 3.7.0