### PR TITLE
bumpup to SpotBugs 3.1.0 RC6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
   </scm>
 
   <properties>
-    <spotbugs.version>3.1.0-RC5</spotbugs.version>
+    <spotbugs.version>3.1.0-RC6</spotbugs.version>
     <jdk.min.version>1.8</jdk.min.version>
 
     <sonar.version>5.6.6</sonar.version>


### PR DESCRIPTION
This version uses BCEL 6.1 and ASM 6.0, so it should work with class files built by Java 9 javac.